### PR TITLE
all: allow with-else-if construct

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -136,6 +136,12 @@ data, defined in detail in the corresponding sections that follow.
 		is executed; otherwise, dot is set to the value of the pipeline
 		and T1 is executed.
 
+	{{with pipeline}} T1 {{else if pipeline}} T0 {{end}}
+		To simplify the appearance of if-else chains with with, the else action
+		of a with action may include another if directly, same as an if action;
+		the effect is exactly the same as writing
+			{{with pipeline}} T1 {{else}}{{if pipeline}} T0 {{end}}{{end}}
+
 Arguments
 
 An argument is a simple value, denoted by one of the following.

--- a/exec_test.go
+++ b/exec_test.go
@@ -526,6 +526,9 @@ var execTests = []execTest{
 	{"with $x struct.U.V", "{{with $x := $}}{{$x.U.V}}{{end}}", "v", tVal, true},
 	{"with variable and action", "{{with $x := $}}{{$y := $.U.V}}{{$y}}{{end}}", "v", tVal, true},
 	{"with on typed nil interface value", "{{with .NonEmptyInterfaceTypedNil}}TRUE{{ end }}", "", tVal, true},
+	{"with else if", "{{with false}}FALSE{{else if true}}TRUE{{.SI}}{{end}}", "TRUE[3 4 5]", tVal, true},
+	{"with else chain", "{{with eq 1 3}}1{{else if eq 2 3}}2{{else if eq 3 3}}3{{end}}", "3", tVal, true},
+	{"with else chain with dot modified", "{{with eq 1 1}}{{.}}{{else if eq 2 3}}2{{else if eq 3 3}}3{{end}}", "true", tVal, true},
 
 	// Range.
 	{"range []int", "{{range .SI}}-{{.}}-{{end}}", "-3--4--5-", tVal, true},

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -513,7 +513,7 @@ func (t *Tree) rangeControl() Node {
 //	{{with pipeline}} itemList {{else}} itemList {{end}}
 // If keyword is past.
 func (t *Tree) withControl() Node {
-	return t.newWith(t.parseControl(false, "with"))
+	return t.newWith(t.parseControl(true, "with"))
 }
 
 // End:

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -240,6 +240,8 @@ var parseTests = []parseTest{
 		`{{with .X}}"hello"{{end}}`},
 	{"with with else", "{{with .X}}hello{{else}}goodbye{{end}}", noError,
 		`{{with .X}}"hello"{{else}}"goodbye"{{end}}`},
+	{"with with else if", "{{with .X}}true{{else if .Y}}false{{end}}", noError, `{{with .X}}"true"{{else}}{{if .Y}}"false"{{end}}{{end}}`},
+	{"with else chain", "+{{with .X}}X{{else if .Y}}Y{{else if .Z}}Z{{end}}+", noError, `"+"{{with .X}}"X"{{else}}{{if .Y}}"Y"{{else}}{{if .Z}}"Z"{{end}}{{end}}{{end}}"+"`},
 	// Trimming spaces.
 	{"trim left", "x \r\n\t{{- 3}}", noError, `"x"{{3}}`},
 	{"trim right", "{{3 -}}\n\n\ty", noError, `{{3}}"y"`},


### PR DESCRIPTION
**Description**
This allows the with-else-if construct.

```
{{ with pipeline }} T1 {{ else if pipeline }} T0 {{ end }}
```
is rewritten to:
```
{{ with pipeline }} T1 {{ else }}{{ if pipeline }} T0 {{ end }}
```

**Status**
Tests are all passing except the newline ones mentioned earlier.