### PR TITLE
template: treat pointers to empty values as empty

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -286,8 +286,8 @@ func (s *state) walk(dot reflect.Value, node parse.Node) {
 // are identical in behavior except that 'with' sets dot.
 func (s *state) walkIfOrWith(typ parse.NodeType, dot reflect.Value, pipe *parse.PipeNode, list, elseList *parse.ListNode) {
 	defer s.pop(s.mark())
-	val := s.evalPipeline(dot, pipe)
-	truth, ok := isTrue(indirectInterface(val))
+	val, _ := indirect(s.evalPipeline(dot, pipe))
+	truth, ok := isTrue(val)
 	if !ok {
 		s.errorf("if/with can't use %v", val)
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -52,6 +52,10 @@ type T struct {
 	MI8S     map[int8]string
 	MUI8S    map[uint8]string
 	SMSI     []map[string]int
+	// Pointers to empty values
+	PtrEmptyMap   *map[string]int
+	PtrEmptySlice *[]int
+	PtrEmptyArray *[0]int
 	// Empty interfaces; used to see if we can dig inside one.
 	Empty0 interface{} // nil
 	Empty1 interface{}
@@ -145,6 +149,9 @@ var tVal = &T{
 		{"one": 1, "two": 2},
 		{"eleven": 11, "twelve": 12},
 	},
+	PtrEmptyMap:               &map[string]int{},
+	PtrEmptySlice:             &[]int{},
+	PtrEmptyArray:             &[0]int{},
 	Empty1:                    3,
 	Empty2:                    "empty2",
 	Empty3:                    []int{7, 8},
@@ -433,6 +440,9 @@ var execTests = []execTest{
 	{"if string", "{{if `notempty`}}NON-EMPTY{{else}}EMPTY{{end}}", "NON-EMPTY", tVal, true},
 	{"if emptyslice", "{{if .SIEmpty}}NON-EMPTY{{else}}EMPTY{{end}}", "EMPTY", tVal, true},
 	{"if slice", "{{if .SI}}NON-EMPTY{{else}}EMPTY{{end}}", "NON-EMPTY", tVal, true},
+	{"if ptr emptymap", "{{if .PtrEmptyMap}}NON-EMPTY{{else}}EMPTY{{end}}", "EMPTY", tVal, true},
+	{"if ptr emptyslice", "{{if .PtrEmptySlice}}NON-EMPTY{{else}}EMPTY{{end}}", "EMPTY", tVal, true},
+	{"if ptr emptyarray", "{{if .PtrEmptyArray}}NON-EMPTY{{else}}EMPTY{{end}}", "EMPTY", tVal, true},
 	{"if emptymap", "{{if .MSIEmpty}}NON-EMPTY{{else}}EMPTY{{end}}", "EMPTY", tVal, true},
 	{"if map", "{{if .MSI}}NON-EMPTY{{else}}EMPTY{{end}}", "NON-EMPTY", tVal, true},
 	{"if map unset", "{{if .MXI.none}}NON-ZERO{{else}}ZERO{{end}}", "ZERO", tVal, true},

--- a/funcs.go
+++ b/funcs.go
@@ -319,7 +319,8 @@ func safeCall(fun reflect.Value, args []reflect.Value) (val reflect.Value, err e
 // Boolean logic.
 
 func truth(arg reflect.Value) bool {
-	t, _ := isTrue(indirectInterface(arg))
+	arg, _ = indirect(arg)
+	t, _ := isTrue(arg)
 	return t
 }
 


### PR DESCRIPTION
Consider the following.
```
{{ dbSet 0 "test" cslice }}
{{ $empty := (dbGet 0 "test").Value }}
{{ $empty }} {{ printf "%T" $empty }}
{{ if $empty }} NOT EMPTY  {{ else }} EMPTY {{ end }}
```
Presently it prints `NOT EMPTY`, since `$empty` is a pointer to an empty slice, and non-nil pointers are treated as truthy by the template executor. Fix this by indirecting prior to considering truthiness.

All tests pass here, including the new ones. Also tested lightly on a selfhost, but more is definitely needed for a change like this. Sadly I don't have the capacity to do so at the moment, but I do want to put this change up for review and consideration.