### PR TITLE
template: refactor error stripping logic, add PassthroughError

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -128,14 +128,36 @@ func (e ExecError) Error() string {
 	return e.Err.Error()
 }
 
-// FuncCallError is the custom error type returned when execution of a list in a
-// try action resulted in an error being returned from a function call.
-type FuncCallError struct {
+// PassthroughError wraps err in such a way that it will not be stripped of
+// information when handled by a try action.
+func PassthroughError(err error) error {
+	return passthroughError{err}
+}
+
+// passthroughError is a wrapper type that indicates to that the wrapped error
+// should not be stripped of additional information if handled by a try action.
+type passthroughError struct {
 	Err error
 }
 
-//strips down all the extra information and just sets error message
-func (f *FuncCallError) strip() error {
+func (p passthroughError) Error() string {
+	return p.Err.Error()
+}
+
+// funcCallError is the wrapper type used internally when execution of a a try
+// action resulted in an error being returned from a function call.
+type funcCallError struct {
+	Err error // Original error.
+}
+
+// Strip removes additional fields and methods from the wrapped error so as to
+// not expose sensitive information. If the wrapped error is of type
+// passthroughError, Strip simply digs down to the wrapped error without
+// performing further sanitization.
+func (f funcCallError) Strip() error {
+	if p, ok := f.Err.(passthroughError); ok {
+		return p.Err
+	}
 	return errors.New(f.Err.Error())
 }
 
@@ -326,8 +348,8 @@ func (s *state) walkTry(dot reflect.Value, list, catchList *parse.ListNode) {
 		s.tryDepth--
 		if r := recover(); r != nil {
 			switch err := r.(type) {
-			case FuncCallError:
-				s.walk(reflect.ValueOf(err.strip()), catchList)
+			case funcCallError:
+				s.walk(reflect.ValueOf(err.Strip()), catchList)
 			default:
 				panic(err)
 			}
@@ -856,7 +878,7 @@ func (s *state) evalCall(dot, fun reflect.Value, node parse.Node, name string, a
 			s.at(node)
 			s.errorf("error calling %s: %v", name, err)
 		}
-		panic(FuncCallError{err})
+		panic(funcCallError{err})
 	}
 	if v.Type() == reflectValueType {
 		v = v.Interface().(reflect.Value)

--- a/exec.go
+++ b/exec.go
@@ -134,8 +134,8 @@ func PassthroughError(err error) error {
 	return passthroughError{err}
 }
 
-// passthroughError is a wrapper type that indicates to that the wrapped error
-// should not be stripped of additional information if handled by a try action.
+// passthroughError is a wrapper type indicating that the wrapped error should
+// not be stripped of additional information if handled by a try action.
 type passthroughError struct {
 	Err error
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -457,8 +457,10 @@ var execTests = []execTest{
 	{"error in catch", "{{try}}{{.MyError true}}{{catch}}{{$.MyError true}}{{end}}", "", tVal, false},
 	{"try catch use error", "{{try}}{{.MyError true}}{{catch}}{{.}}{{end}}", "my error", tVal, true},
 	{"nested try catch", "{{try}}{{.MyError true}}{{catch}}{{try}}{{$.MyError true}}{{catch}}abc{{end}}{{end}}", "abc", tVal, true},
-	// should not catch panics.
-	{"try catch with panic", "{{try}}{{makemap 1}}{{catch}}x{{end}}", "", tVal, false},
+	{"try catch with panic", "{{try}}{{makemap 1}}{{catch}}x{{end}}", "", tVal, false}, // shouldn't catch panics
+	{"strips error fields", "{{try}}{{returnError}}{{catch}}{{.X}}{{end}}", "", tVal, false},
+	{"keeps original error message", "{{try}}{{returnError}}{{catch}}{{.Error}}{{end}}", "bye", tVal, true},
+	{"does not strip errors wrapped using PassthroughError", "{{try}}{{returnPassthroughError}}{{catch}}{{.X}}{{end}}", "1", tVal, true},
 
 	// Print etc.
 	{"print", `{{print "hello, print"}}`, "hello, print", tVal, true},
@@ -778,24 +780,43 @@ func mapOfThree() interface{} {
 	return map[string]int{"three": 3}
 }
 
+type customError struct {
+	X int
+	Y string
+}
+
+func (c customError) Error() string {
+	return c.Y
+}
+
+func returnPassthroughError() (string, error) {
+	return "", PassthroughError(customError{1, "hi"})
+}
+
+func returnError() (string, error) {
+	return "", customError{1, "bye"}
+}
+
 func testExecute(execTests []execTest, template *Template, t *testing.T) {
 	b := new(bytes.Buffer)
 	funcs := FuncMap{
-		"mult":        mult,
-		"add":         add,
-		"count":       count,
-		"dddArg":      dddArg,
-		"echo":        echo,
-		"makemap":     makemap,
-		"mapOfThree":  mapOfThree,
-		"oneArg":      oneArg,
-		"returnInt":   returnInt,
-		"stringer":    stringer,
-		"twoArgs":     twoArgs,
-		"typeOf":      typeOf,
-		"valueString": valueString,
-		"vfunc":       vfunc,
-		"zeroArgs":    zeroArgs,
+		"mult":                   mult,
+		"add":                    add,
+		"count":                  count,
+		"dddArg":                 dddArg,
+		"echo":                   echo,
+		"makemap":                makemap,
+		"mapOfThree":             mapOfThree,
+		"oneArg":                 oneArg,
+		"returnInt":              returnInt,
+		"stringer":               stringer,
+		"twoArgs":                twoArgs,
+		"typeOf":                 typeOf,
+		"valueString":            valueString,
+		"vfunc":                  vfunc,
+		"zeroArgs":               zeroArgs,
+		"returnPassthroughError": returnPassthroughError,
+		"returnError":            returnError,
 	}
 	for _, test := range execTests {
 		var tmpl *Template
@@ -1664,6 +1685,14 @@ func TestExecutePanicDuringCall(t *testing.T) {
 			}
 			t.Errorf("%s: expected error:\n%s\ngot:\n%s", tc.name, tc.wantErr, err)
 		}
+	}
+}
+
+func TestPassthroughError(t *testing.T) {
+	const msg = "msg"
+	err := PassthroughError(errors.New(msg))
+	if err.Error() != msg {
+		t.Fatalf("err.Error() = %q, want %q", err.Error(), msg)
 	}
 }
 


### PR DESCRIPTION
Refactor the error stripping logic slightly, and add tests to ensure everything works as intended.
Also add `PassthroughError`, which can be used in a template function to prevent fields from being stripped on a case-by-case basis:
```go
func f() (string, error) {
    // ...
    return "", template.PassthroughError(customError)
}
```
To be clear, by default errors will still be stripped of extra information besides the message; `PassthroughError` simply enables exposing additional non-sensitive information for certain errors in the future if we so desire.